### PR TITLE
Update permissions asks on Android

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -547,12 +547,39 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
     final int cameraPermission = ActivityCompat
             .checkSelfPermission(activity, Manifest.permission.CAMERA);
 
-    final boolean permissionsGrated = writePermission == PackageManager.PERMISSION_GRANTED &&
-            cameraPermission == PackageManager.PERMISSION_GRANTED;
+    final boolean permissionsGrated;
+
+    switch (requestCode)
+    {
+      case REQUEST_PERMISSIONS_FOR_CAMERA:
+        permissionsGrated = cameraPermission == PackageManager.PERMISSION_GRANTED;
+        break;
+
+      case REQUEST_PERMISSIONS_FOR_LIBRARY:
+        permissionsGrated = writePermission == PackageManager.PERMISSION_GRANTED;
+        break;
+
+      default:
+        permissionsGrated = cameraPermission == PackageManager.PERMISSION_GRANTED && writePermission == PackageManager.PERMISSION_GRANTED;
+    }
 
     if (!permissionsGrated)
     {
-      final Boolean dontAskAgain = ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE) && ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.CAMERA);
+      final Boolean dontAskAgain;
+
+      switch (requestCode)
+      {
+        case REQUEST_PERMISSIONS_FOR_CAMERA:
+          dontAskAgain = ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.CAMERA);
+          break;
+
+        case REQUEST_PERMISSIONS_FOR_LIBRARY:
+          dontAskAgain = ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE);
+          break;
+
+        default:
+          dontAskAgain = ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.CAMERA) && ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE);
+      }
 
       if (dontAskAgain)
       {
@@ -599,6 +626,17 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
       else
       {
         String[] PERMISSIONS = {Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.CAMERA};
+        switch (requestCode)
+        {
+          case REQUEST_PERMISSIONS_FOR_CAMERA:
+            PERMISSIONS = new String[]{Manifest.permission.CAMERA};
+            break;
+
+          case REQUEST_PERMISSIONS_FOR_LIBRARY:
+            PERMISSIONS = new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE};
+            break;
+        }
+
         if (activity instanceof ReactActivity)
         {
           ((ReactActivity) activity).requestPermissions(PERMISSIONS, requestCode, listener);


### PR DESCRIPTION
Have it ask for camera or library permissions, and not both, on Android.

Taken from this fork: https://github.com/mreda7/react-native-image-picker