### PR TITLE
Revert "Use gradle 3.2.1 (#2)"

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,15 +10,10 @@ def computeVersionName() {
 buildscript {
     repositories {
         jcenter()
-        mavenCentral()
-        maven {
-            url 'https://maven.google.com/'
-            name 'Google'
-        }
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:2.2.+'
     }
 }
 


### PR DESCRIPTION
We fixed this in keybase/client instead.